### PR TITLE
Added WorkflowFailedException, and get_workflow_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ class MyWorkflow(pyflow.Workflow):
     other_func = pyflow.LambdaDescriptor('other_lambda_func')
     
     def run(self, input_arg):
+       if input_arg == 'bad_input':
+           raise pyflow.WorkflowFailedException('BAD_INPUT', 'Received bad input')
+           
        future1 = self.some_func(input_arg)
        
        x = future1.result() + 2
@@ -81,6 +84,11 @@ Workflow Worker process so it can process other SWF events.  I'll
 explain later in this document how the context switching is
 implemented, as well as some rules you need to follow in your workflow
 implementation code as a result of this implementation.
+
+The code above also demonstrates how to signal a workflow failure.
+Raise the `WorkflowFailedException` with two arguments.  The first is
+a short `reason` string, and the second is a longer `details` string.
+
 
 ### Executing a Workflow
 

--- a/examples/string_transformer_execute.py
+++ b/examples/string_transformer_execute.py
@@ -5,7 +5,7 @@ def main():
     domain = 'SWFSampleDomain'
     task_list = 'string-transformer-decider'
     workflow_name = 'StringTransformer'
-    workflow_version = '1.0'
+    workflow_version = '1.1'
     lambda_role='arn:aws:iam::528461152743:role/swf-lambda'
 
     execution_info = pyflow.start_workflow(

--- a/examples/string_transformer_workflow.py
+++ b/examples/string_transformer_workflow.py
@@ -5,11 +5,13 @@ import pyflow
 
 class StringTransformer(pyflow.Workflow):
     NAME = 'StringTransformer'
-    VERSION = '1.0'
-    OPTIONS = {'lambdaRole': 'arn:aws:iam::528461152743:role/swf-lambda'}
+    VERSION = '1.1'
+    OPTIONS = {'defaultLambdaRole': 'arn:aws:iam::528461152743:role/swf-lambda',
+               'defaultTaskStartToCloseTimeout': 60}
 
     # Descriptors provide a way to declare shortcuts for remote invocations
     string_upcase = pyflow.LambdaDescriptor('string_upcase')
+    string_concat = pyflow.ChildWorkflowDescriptor('StringConcatter', '1.2')
 
     def run(self, workflow_input):
         # for loops work.  In this case upcased will contain a list of futures
@@ -39,17 +41,15 @@ class StringTransformer(pyflow.Workflow):
                                               task_list='subscription-activities')
         print "Subscription info: {}".format(subscribed.result())
 
-        concatted = self.swf.invoke_child_workflow('StringConcatter', '1.0',
-                                                   input_arg=[s.result() for s in reversed_strs],
-                                                   lambda_role=self.swf.lambda_role)
+        concatted = self.string_concat([s.result() for s in reversed_strs])
 
         return concatted.result()
 
 
 class StringConcatter(pyflow.Workflow):
     NAME = 'StringConcatter'
-    VERSION = '1.0'
-    OPTIONS = {'lambdaRole': 'arn:aws:iam::528461152743:role/swf-lambda'}
+    VERSION = '1.2'
+    OPTIONS = {'defaultLambdaRole': 'arn:aws:iam::528461152743:role/swf-lambda'}
 
     def run(self, workflow_input):
         return self.swf.invoke_lambda('string_concat', workflow_input).result()
@@ -59,7 +59,7 @@ def main():
     logging.basicConfig()
     pyflow.decider.logger.setLevel(logging.DEBUG)
 
-    workflows = [StringTransformer(), StringConcatter()]
+    workflows = [StringTransformer, StringConcatter]
     domain = 'SWFSampleDomain'
     task_list = 'string-transformer-decider'
 

--- a/pyflow/decision_task_helper.py
+++ b/pyflow/decision_task_helper.py
@@ -125,6 +125,9 @@ class DecisionTaskHelper(object):
         if child_policy is not None:
             attributes['childPolicy'] = child_policy
 
+        if lambda_role is None:
+            lambda_role = self.workflow_state.lambda_role
+
         if lambda_role is not None:
             attributes['lambdaRole'] = lambda_role
 

--- a/pyflow/exceptions.py
+++ b/pyflow/exceptions.py
@@ -15,6 +15,23 @@ class WorkflowBlockedException(Exception):
     pass
 
 
+class WorkflowFailedException(PyflowException):
+    """
+    Exception which can be thrown by a workflow function to explicitly request that the workflow be marked as failed,
+    with a given reason and details string.
+    """
+    def __init__(self, reason, details):
+        super(WorkflowFailedException, self).__init__(reason, details)
+
+    @property
+    def reason(self):
+        return self.args[0]
+
+    @property
+    def details(self):
+        return self.args[1]
+
+
 class InvocationException(PyflowException):
     """Base class of exceptions related to invocations failing."""
     pass

--- a/pyflow/invocation_descriptors.py
+++ b/pyflow/invocation_descriptors.py
@@ -20,7 +20,7 @@ class LambdaDescriptor(object):
             # The lambda function name is a required parameter
             my_function = pyflow.LambdaDescriptor('my_function')
             # Can also optionally specify a timeout
-            other_function = pyflow.LambdaDescript('other_lambda_func', timeout=120)
+            other_function = pyflow.LambdaDescriptor('other_lambda_func', timeout=120)
 
             def run(self, input):
                 # these two calls are equivalent

--- a/pyflow/utils.py
+++ b/pyflow/utils.py
@@ -39,6 +39,13 @@ def list_activity_types(swf, domain):
         'typeInfos')
 
 
+def list_workflow_history(swf, domain, workflow_id, run_id, reverse=False):
+    paginator = swf.get_paginator('get_workflow_execution_history')
+    return iter_collection(
+        paginator.paginate(domain=domain, execution={'workflowId': workflow_id, 'runId': run_id}, reverseOrder=reverse),
+        'events')
+
+
 def poll_for_decision_tasks(swf, domain, task_list, identity):
     paginator = swf.get_paginator('poll_for_decision_task')
     result = None

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
 
 setup(
     name='pyflow-swf',
-    version='1.1.0',
+    version='1.2.0',
     author='Adam Jenkins',
     author_email='adam@thejenkins.org',
     license='MIT',


### PR DESCRIPTION
Added a WorkflowFailedException type, that users can throw to intentionally signal that a workflow failed, and provide the `reason` and `details` strings for the WorkflowFailed event.

Added a get_workflow_status function, which allows getting status information about a running or closed workflow execution.