### PR TITLE
Added support for retrying lambda invocations on internal errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - pip install -U pytest
 
 script:
-- pytest tests
+- env AWS_DEFAULT_REGION=us-west-2 pytest tests
 
 deploy:
   provider: pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.2
+
+* Added support for retrying lambda invocations which fail due to internal errors
+
 # 1.6.0
 * Added additional parameters to `start_workflow()`
 

--- a/pyflow/workflow_state.py
+++ b/pyflow/workflow_state.py
@@ -19,7 +19,11 @@ class InvocationState(object):
 
     invocation_id = attr.ib()
 
+    invocation_args = attr.ib(default=None)
+
     state = attr.ib(default=NOT_STARTED)
+
+    retries_left = attr.ib(default=0)
 
     result = attr.ib(default=None)
 
@@ -67,16 +71,20 @@ class WorkflowState(object):
     # The id of the last event added to the state
     last_seen_event_id = attr.ib(default=None)
 
-    def get_invocation_state(self, invocation_id, initial_state=InvocationState.NOT_STARTED):
+    def get_invocation_state(self, invocation_id, initial_state=InvocationState.NOT_STARTED, num_retries=0,
+                             invocation_args=None):
         """
         Gets the invocation state for an invocation_id, creating a new state if none exists
 
         :param invocation_id: The invocation id of the state to fetch
         :param initial_state: The initial value to set the state property to if a new InvocationState is created
+        :param num_retries: Number of retries this invocation should be created with
+        :param invocation_args: Arguments used to initiate this invocation
         :return: The InvocationState object for invocation_id
         """
         invocation_state = self.invocation_states.get(invocation_id)
         if invocation_state is None:
             invocation_state = self.invocation_states[invocation_id] = InvocationState(
-                invocation_id=invocation_id, state=initial_state)
+                invocation_id=invocation_id, state=initial_state, retries_left=num_retries,
+                invocation_args=invocation_args)
         return invocation_state

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
 
 setup(
     name='pyflow-swf',
-    version='1.6.1',
+    version='1.6.2',
     author='Adam Jenkins',
     author_email='adam@thejenkins.org',
     license='MIT',

--- a/tests/decider/test_decider.py
+++ b/tests/decider/test_decider.py
@@ -75,16 +75,16 @@ class StringConcatter(pyflow.Workflow):
 
 
 @pytest.fixture
-def s3_client():
-    """Returns a mock boto3 S3 client.  See botocore.stub.Stubber docstring for how to use it"""
-    return botocore.stub.Stubber(boto3.client('s3'))
+def swf_client():
+    """Returns a mock boto3 SWF client.  See botocore.stub.Stubber docstring for how to use it"""
+    return botocore.stub.Stubber(boto3.client('swf'))
 
 
 @pytest.fixture
-def decider(s3_client):
+def decider(swf_client):
     return pyflow.Decider([StringTransformer, StringConcatter],
                           domain='test-domain', task_list='string-transformer-decider',
-                          identity='string transformer decider', client=s3_client)
+                          identity='string transformer decider', client=swf_client)
 
 
 @attr.s
@@ -221,7 +221,7 @@ def test_process_decision_task(decider, test_case):
     assert test_case.expected_decisions == decision_helper.decisions
 
 
-def test_process_decision_maker_cumulative(decider):
+def test_process_decision_task_cumulative(decider):
     """Like test_process_decision_task, but process all decision tasks in one decider instance"""
     for test_case in process_decision_task_test_cases:
         decision_helper = decider.process_decision_task(test_case.decision_task)


### PR DESCRIPTION
Lambda invocations which fail with reason `SdkClientException` or `ServiceException` will automatically be retried up to 5 times.  These are internal errors in the SWF service that sometimes occur when it tries to invoke a lambda.